### PR TITLE
Update version to 2.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f619a51371f41c0ad6837b2a98af9d4643b3371015d873887f7e8d3237320b2f
 
 build:
-  number: 1
+  number: 0
   run_exports:
     # seems to change SONAME every minor version
     # https://abi-laboratory.pro/tracker/timeline/gflags/
@@ -37,7 +37,6 @@ test:
     - if not exist %PREFIX%\\Library\\bin\\gflags.dll exit 1          # [win]
     - if not exist %PREFIX%\\Library\\lib\\gflags.lib exit 1          # [win]
     - if not exist %PREFIX%\\Library\\lib\\gflags_static.lib exit 1   # [win]
-
 
 about:
   home: https://github.com/gflags/gflags

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,13 @@
 {% set name = "gflags" %}
-{% set version = "2.2.2" %}
+{% set version = "2.3.0" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://github.com/gflags/gflags/archive/v{{ version }}.tar.gz
-  sha256: 34af2f15cf7367513b352bdcd2493ab14ce43692d2dcd9dfc499492966c64dcf
+  url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: f619a51371f41c0ad6837b2a98af9d4643b3371015d873887f7e8d3237320b2f
 
 build:
   number: 1
@@ -19,6 +18,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake
@@ -47,7 +47,7 @@ about:
   summary: A C++ library that implements commandline flags processing.
   description: |
     gflags are Commandline flags that Users specify on the command line when they run an executable.
-  doc_url: https://gflags.github.io/gflags/
+  doc_url: https://gflags.github.io/gflags
   dev_url: https://github.com/gflags/gflags
 
 extra:


### PR DESCRIPTION
gflags 2.3.0

**Destination channel:** defaults

### Links

- [PKG-11271](https://anaconda.atlassian.net/browse/PKG-11271) 
- [Upstream repository](https://github.com/gflags/gflags/tree/v2.3.0)

### Explanation of changes:

- New version number


[PKG-11271]: https://anaconda.atlassian.net/browse/PKG-11271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ